### PR TITLE
Implement IEarlyMixinLoader on SodiumDynamicLightsLoadingPlugin

### DIFF
--- a/src/main/java/toni/sodiumdynamiclights/SodiumDynamicLightsLoadingPlugin.java
+++ b/src/main/java/toni/sodiumdynamiclights/SodiumDynamicLightsLoadingPlugin.java
@@ -4,10 +4,13 @@ import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.launch.MixinBootstrap;
 import org.spongepowered.asm.mixin.Mixins;
+import zone.rong.mixinbooter.IEarlyMixinLoader;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
-public class SodiumDynamicLightsLoadingPlugin implements IFMLLoadingPlugin {
+public class SodiumDynamicLightsLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader {
     @Override
     public @Nullable String[] getASMTransformerClass() {
         return new String[0];
@@ -31,4 +34,9 @@ public class SodiumDynamicLightsLoadingPlugin implements IFMLLoadingPlugin {
     public @Nullable String getAccessTransformerClass() {
         return null;
     }
+
+	@Override
+	public List<String> getMixinConfigs() {
+		return Collections.singletonList("celeritasdynamiclights.default.mixin.json");
+	}
 }


### PR DESCRIPTION
Fixes compatibility with non-Cleanroom environments.

I wasn't able to get the Gradle project to import (even without these changes), but this should still work fine.

Fixes #5.